### PR TITLE
BF: .tobytes() to avoid ctypes.ArgumentError: argument 2: <class TypeError>: wrong type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,13 +29,5 @@ niicat T1.nii.gz
 
 If nothing is displayed check if your [terminal supports sixel](https://github.com/saitoha/libsixel#terminal-requirements).
 
-You might also encounter the following error message:
-```
-ctypes.ArgumentError: argument 2: <class 'TypeError'>: wrong type
-```
-This is a known [problem](https://github.com/fastai/fastai/issues/2170) when using libsixel-python. 
-In this case try using niicat with the option `-ic` if you are using iterm2 (this will use `imgcat` from iterm2) or 
-with the option `-lb` (this will use `libsixel-bin` which can be installed via `sudo apt install libsixel-bin`).
-
 Niicat was only tested on python >= 3.5.
 

--- a/niicat/plotter.py
+++ b/niicat/plotter.py
@@ -33,7 +33,7 @@ def _plot_sixel(fig=None):
     if fig is None: fig = plt.gcf()
     fig.canvas.draw()
     dpi = fig.get_dpi()
-    res = _sixel_encode(fig.canvas.buffer_rgba(), fig.get_figwidth()* dpi, fig.get_figheight() * dpi)
+    res = _sixel_encode(fig.canvas.buffer_rgba().tobytes(), fig.get_figwidth()* dpi, fig.get_figheight() * dpi)
     print(res)
 
 


### PR DESCRIPTION
Solution borrowed from https://github.com/fastai/fastai/issues/2170#issuecomment-635680946
    
For me niicat shows nothing, but I might still need to learn in which terminal app
and with what settings it should work, but at least it does not crash.... update: tested in xterm (instead of gnome-terminal) -- seems to work!
